### PR TITLE
Correct the DTU WEC LP filter corner frequency

### DIFF
--- a/HAWC2/IEA-15-240-RWT-FixedBottom/htc/IEA_15MW_RWT.htc
+++ b/HAWC2/IEA-15-240-RWT-FixedBottom/htc/IEA_15MW_RWT.htc
@@ -382,7 +382,7 @@ begin dll;
 								; from a file named 'wptable.n', where n=int(theta_min)
       constant   6 90.0 ; Maximum pitch angle [deg]
       constant   7 2.0 ; Maximum pitch velocity operation [deg/s]
-      constant   8 1.0081 ; Frequency of generator speed filter [Hz]
+      constant   8 0.15915 ; Frequency of generator speed filter [Hz]
       constant   9 0.7 ; Damping ratio of speed filter [-]
       constant  10   1.01   	; Frequency of free-free DT torsion mode [Hz], if zero no notch filter used
       ; Partial load control parameters


### PR DESCRIPTION
The corner frequency in the DTU WEC block was incorrectly given as 1 Hz, when it should have been 1 rad/s.