### PR TITLE
tower damping in hawc tuned to 1pc critical

### DIFF
--- a/HAWC2/IEA-15-240-RWT-FixedSubstructure/htc/IEA_15MW_RWT_FixedSubstructure.htc
+++ b/HAWC2/IEA-15-240-RWT-FixedSubstructure/htc/IEA_15MW_RWT_FixedSubstructure.htc
@@ -26,7 +26,7 @@ begin new_htc_structure;
     type        timoschenko ;
     nbodies     1 ;
     node_distribution     c2_def ;
-    damping_posdef   0.0 0.0 0.0 1.327E-03 1.327E-03 5.553e-5  ; tuned to 2% log dec on 1st FA/SS/torsion modes (#1, #2, #7)
+    damping_posdef   0.0 0.0 0.0 0.004 0.004 0.0004  ; tuned to 1% critical (approx 6% log dec) on 1st FA(0.79 Hz)/SS(0.79 Hz)/torsion(8 Hz) modes (#1, #2, #7)
     begin timoschenko_input;
       filename ./data/IEA_15MW_RWT_Tower_st.dat;
       set 1 1 ;

--- a/HAWC2/IEA-15-240-RWT-UMaineSemi/htc/IEA_15MW_RWT_UMaineSemi.htc
+++ b/HAWC2/IEA-15-240-RWT-UMaineSemi/htc/IEA_15MW_RWT_UMaineSemi.htc
@@ -44,7 +44,7 @@ begin new_htc_structure;
     type        timoschenko ;
     nbodies     1 ;
     node_distribution     c2_def ;
-    damping_posdef   0.0 0.0 0.0 1.12E-02 1.10E-02 1.194E-04  ; tuned to 2% log dec on 1st FA/SS/torsion modes (#1, #2, #7)
+    damping_posdef   0.0 0.0 0.0 0.004 0.004 0.0004  ; tuned to 1% critical (approx 6% log dec) on 1st FA(0.79 Hz)/SS(0.79 Hz)/torsion(8 Hz) modes (#1, #2, #7)
     begin timoschenko_input;
       filename data/IEA_15MW_RWT_UMaineSemi_Tower_st.dat;
       set 1 1 ;

--- a/HAWC2/IEA-15-240-RWT-UMaineSemi/htc/IEA_15MW_RWT_UMaineSemi_floater_init.htc
+++ b/HAWC2/IEA-15-240-RWT-UMaineSemi/htc/IEA_15MW_RWT_UMaineSemi_floater_init.htc
@@ -44,7 +44,7 @@ begin new_htc_structure;
     type        timoschenko ;
     nbodies     1 ;
     node_distribution     c2_def ;
-    damping_posdef   0.0 0.0 0.0 1.12E-02 1.10E-02 1.194E-04  ; tuned to 2% log dec on 1st FA/SS/torsion modes (#1, #2, #7)
+    damping_posdef   0.0 0.0 0.0 0.004 0.004 0.0004  ; tuned to 1% critical (approx 6% log dec) on 1st FA(0.79 Hz)/SS(0.79 Hz)/torsion(8 Hz) modes (#1, #2, #7)
     begin timoschenko_input;
       filename data/IEA_15MW_RWT_UMaineSemi_Tower_st.dat;
       set 1 1 ;


### PR DESCRIPTION
This PR updates the damping of the tower in HAWC2 tuning to 1% critical. This corresponds to approximately 6% log dec. This value is applied to the two towers, mounted on monopile and floater. This change is not necessarily moving the model toward being realistic, but at least it ensures consistency with the tower modeled in OpenFAST. There is great uncertainty in setting these values of damping and future studies should investigate the impact of these numbers and what values should be adopted in the aeroservohydroelastic models.