### PR TITLE
Simple vs ctrl

### DIFF
--- a/OpenFAST/IEA-15-240-RWT-Monopile/IEA-15-240-RWT-Monopile_ElastoDyn_tower.dat
+++ b/OpenFAST/IEA-15-240-RWT-Monopile/IEA-15-240-RWT-Monopile_ElastoDyn_tower.dat
@@ -2,10 +2,10 @@
 IEA 15 MW offshore reference model monopile configuration
 ---------------------- TOWER PARAMETERS ----------------------------------------
 20                     NTwInpSt    - Number of input stations to specify tower geometry
-0.32                   TwrFADmp(1) - Tower 1st fore-aft mode structural damping ratio (%)
-0.32                   TwrFADmp(2) - Tower 2nd fore-aft mode structural damping ratio (%)
-0.32                   TwrSSDmp(1) - Tower 1st side-to-side mode structural damping ratio (%)
-0.32                   TwrSSDmp(2) - Tower 2nd side-to-side mode structural damping ratio (%)
+1.0                    TwrFADmp(1) - Tower 1st fore-aft mode structural damping ratio (%)
+1.0                    TwrFADmp(2) - Tower 2nd fore-aft mode structural damping ratio (%)
+1.0                    TwrSSDmp(1) - Tower 1st side-to-side mode structural damping ratio (%)
+1.0                    TwrSSDmp(2) - Tower 2nd side-to-side mode structural damping ratio (%)
 ---------------------- TOWER ADJUSTMUNT FACTORS --------------------------------
 1.0                    FAStTunr(1) - Tower fore-aft modal stiffness tuner, 1st mode (-)
 1.0                    FAStTunr(2) - Tower fore-aft modal stiffness tuner, 2nd mode (-)

--- a/OpenFAST/IEA-15-240-RWT-Monopile/IEA-15-240-RWT-Monopile_ServoDyn.dat
+++ b/OpenFAST/IEA-15-240-RWT-Monopile/IEA-15-240-RWT-Monopile_ServoDyn.dat
@@ -25,10 +25,10 @@ True                   GenTiStp    - Method to stop the generator {T: timed usin
 0.0                    TimGenOn    - Time to turn on the generator for a startup (s) [used only when GenTiStr=True]
 9999.9                 TimGenOf    - Time to turn off the generator (s) [used only when GenTiStp=True]
 ---------------------- SIMPLE VARIABLE-SPEED TORQUE CONTROL --------------------
-9999.9                 VS_RtGnSp   - Rated generator speed for simple variable-speed generator control (HSS side) (rpm) [used only when VSContrl=1]
-9999.9                 VS_RtTq     - Rated generator torque/constant generator torque in Region 3 for simple variable-speed generator control (HSS side) (N-m) [used only when VSContrl=1]
-9999.9                 VS_Rgn2K    - Generator torque constant in Region 2 for simple variable-speed generator control (HSS side) (N-m/rpm^2) [used only when VSContrl=1]
-9999.9                 VS_SlPc     - Rated generator slip percentage in Region 2 1/2 for simple variable-speed generator control (%) [used only when VSContrl=1]
+7.559987120819503      VS_RtGnSp   - Rated generator speed for simple variable-speed generator control (HSS side) (rpm) [used only when VSContrl=1]
+19624046.66639         VS_RtTq     - Rated generator torque/constant generator torque in Region 3 for simple variable-speed generator control (HSS side) (N-m) [used only when VSContrl=1]
+343357.4355671095      VS_Rgn2K    - Generator torque constant in Region 2 for simple variable-speed generator control (HSS side) (N-m/rpm^2) [used only when VSContrl=1]
+2.                     VS_SlPc     - Rated generator slip percentage in Region 2 1/2 for simple variable-speed generator control (%) [used only when VSContrl=1]
 ---------------------- SIMPLE INDUCTION GENERATOR ------------------------------
 9999.9                 SIG_SlPc    - Rated generator slip percentage (%) [used only when VSContrl=0 and GenModel=1]
 9999.9                 SIG_SySp    - Synchronous (zero-torque) generator speed (rpm) [used only when VSContrl=0 and GenModel=1]

--- a/OpenFAST/IEA-15-240-RWT-Monopile_wDTUcontroller/IEA-15-240-RWT-Monopile_ServoDyn_wDTUcontroller.dat
+++ b/OpenFAST/IEA-15-240-RWT-Monopile_wDTUcontroller/IEA-15-240-RWT-Monopile_ServoDyn_wDTUcontroller.dat
@@ -25,10 +25,10 @@ True                   GenTiStp    - Method to stop the generator {T: timed usin
 0.0                    TimGenOn    - Time to turn on the generator for a startup (s) [used only when GenTiStr=True]
 9999.9                 TimGenOf    - Time to turn off the generator (s) [used only when GenTiStp=True]
 ---------------------- SIMPLE VARIABLE-SPEED TORQUE CONTROL --------------------
-9999.9                 VS_RtGnSp   - Rated generator speed for simple variable-speed generator control (HSS side) (rpm) [used only when VSContrl=1]
-9999.9                 VS_RtTq     - Rated generator torque/constant generator torque in Region 3 for simple variable-speed generator control (HSS side) (N-m) [used only when VSContrl=1]
-9999.9                 VS_Rgn2K    - Generator torque constant in Region 2 for simple variable-speed generator control (HSS side) (N-m/rpm^2) [used only when VSContrl=1]
-9999.9                 VS_SlPc     - Rated generator slip percentage in Region 2 1/2 for simple variable-speed generator control (%) [used only when VSContrl=1]
+7.559987120819503      VS_RtGnSp   - Rated generator speed for simple variable-speed generator control (HSS side) (rpm) [used only when VSContrl=1]
+19624046.66639         VS_RtTq     - Rated generator torque/constant generator torque in Region 3 for simple variable-speed generator control (HSS side) (N-m) [used only when VSContrl=1]
+343357.4355671095      VS_Rgn2K    - Generator torque constant in Region 2 for simple variable-speed generator control (HSS side) (N-m/rpm^2) [used only when VSContrl=1]
+2.                     VS_SlPc     - Rated generator slip percentage in Region 2 1/2 for simple variable-speed generator control (%) [used only when VSContrl=1]
 ---------------------- SIMPLE INDUCTION GENERATOR ------------------------------
 9999.9                 SIG_SlPc    - Rated generator slip percentage (%) [used only when VSContrl=0 and GenModel=1]
 9999.9                 SIG_SySp    - Synchronous (zero-torque) generator speed (rpm) [used only when VSContrl=0 and GenModel=1]

--- a/OpenFAST/IEA-15-240-RWT-UMaineSemi/IEA-15-240-RWT-UMaineSemi_ServoDyn.dat
+++ b/OpenFAST/IEA-15-240-RWT-UMaineSemi/IEA-15-240-RWT-UMaineSemi_ServoDyn.dat
@@ -25,10 +25,10 @@ True                   GenTiStp    - Method to stop the generator {T: timed usin
 0.0                    TimGenOn    - Time to turn on the generator for a startup (s) [used only when GenTiStr=True]
 9999.9                 TimGenOf    - Time to turn off the generator (s) [used only when GenTiStp=True]
 ---------------------- SIMPLE VARIABLE-SPEED TORQUE CONTROL --------------------
-9999.9                 VS_RtGnSp   - Rated generator speed for simple variable-speed generator control (HSS side) (rpm) [used only when VSContrl=1]
-9999.9                 VS_RtTq     - Rated generator torque/constant generator torque in Region 3 for simple variable-speed generator control (HSS side) (N-m) [used only when VSContrl=1]
-9999.9                 VS_Rgn2K    - Generator torque constant in Region 2 for simple variable-speed generator control (HSS side) (N-m/rpm^2) [used only when VSContrl=1]
-9999.9                 VS_SlPc     - Rated generator slip percentage in Region 2 1/2 for simple variable-speed generator control (%) [used only when VSContrl=1]
+7.559987120819503      VS_RtGnSp   - Rated generator speed for simple variable-speed generator control (HSS side) (rpm) [used only when VSContrl=1]
+19624046.66639         VS_RtTq     - Rated generator torque/constant generator torque in Region 3 for simple variable-speed generator control (HSS side) (N-m) [used only when VSContrl=1]
+343357.4355671095      VS_Rgn2K    - Generator torque constant in Region 2 for simple variable-speed generator control (HSS side) (N-m/rpm^2) [used only when VSContrl=1]
+2.                     VS_SlPc     - Rated generator slip percentage in Region 2 1/2 for simple variable-speed generator control (%) [used only when VSContrl=1]
 ---------------------- SIMPLE INDUCTION GENERATOR ------------------------------
 9999.9                 SIG_SlPc    - Rated generator slip percentage (%) [used only when VSContrl=0 and GenModel=1]
 9999.9                 SIG_SySp    - Synchronous (zero-torque) generator speed (rpm) [used only when VSContrl=0 and GenModel=1]


### PR DESCRIPTION
This PR brings back tower structural damping from 0.32% crit to 1% crit. With 0.32%, the design is unstable at high winds and at this stage it might be best for everyone to accept the 1% as lesser evil. This PR also tunes the simple variable speed controller of ServoDyn to support linearization studies.
