### PR TITLE
Improve mode shape coefficients for OpenFAST, especially for 2nd modes

### DIFF
--- a/OpenFAST/IEA-15-240-RWT-Monopile/IEA-15-240-RWT-Monopile_ElastoDyn_tower.dat
+++ b/OpenFAST/IEA-15-240-RWT-Monopile/IEA-15-240-RWT-Monopile_ElastoDyn_tower.dat
@@ -38,24 +38,24 @@ IEA 15 MW offshore reference model monopile configuration
  9.042786700261230E-01  4.120141253172980E+03  5.291723868157960E+11  5.291723868157960E+11
  1.000000000000000E+00  4.074837331422720E+03  5.119078821628500E+11  5.119078821628500E+11
 ---------------------- TOWER FORE-AFT MODE SHAPES ------------------------------
-0.940629055234494      TwFAM1Sh(2) - Mode 1, coefficient of x^2 term
--0.11131971295705372   TwFAM1Sh(3) -       , coefficient of x^3 term
--0.1689308438200212    TwFAM1Sh(4) -       , coefficient of x^4 term
-0.9870807522447572     TwFAM1Sh(5) -       , coefficient of x^5 term
--0.6474592507021764    TwFAM1Sh(6) -       , coefficient of x^6 term
--0.4098126359223273    TwFAM2Sh(2) - Mode 2, coefficient of x^2 term
-2.014615886316636      TwFAM2Sh(3) -       , coefficient of x^3 term
--3.780431497994439     TwFAM2Sh(4) -       , coefficient of x^4 term
-5.518464819150487      TwFAM2Sh(5) -       , coefficient of x^5 term
--2.342836571550357     TwFAM2Sh(6) -       , coefficient of x^6 term
+1.03778636             TwFAM1Sh(2) - Mode 1, coefficient of x^2 term
+0.1436668              TwFAM1Sh(3) -       , coefficient of x^3 term
+-0.6087589             TwFAM1Sh(4) -       , coefficient of x^4 term
+0.60504535             TwFAM1Sh(5) -       , coefficient of x^5 term
+-0.17773961            TwFAM1Sh(6) -       , coefficient of x^6 term
+-2.01580901            TwFAM2Sh(2) - Mode 2, coefficient of x^2 term
+1.8289981              TwFAM2Sh(3) -       , coefficient of x^3 term
+3.38258371             TwFAM2Sh(4) -       , coefficient of x^4 term
+-2.35113271            TwFAM2Sh(5) -       , coefficient of x^5 term
+0.15535992             TwFAM2Sh(6) -       , coefficient of x^6 term
 ---------------------- TOWER SIDE-TO-SIDE MODE SHAPES --------------------------
-0.9311777730302138     TwSSM1Sh(2) - Mode 1, coefficient of x^2 term
--0.09476520851076765   TwSSM1Sh(3) -       , coefficient of x^3 term
--0.2049426588352373    TwSSM1Sh(4) -       , coefficient of x^4 term
-1.0275535540013145     TwSSM1Sh(5) -       , coefficient of x^5 term
--0.6590234596855233    TwSSM1Sh(6) -       , coefficient of x^6 term
--0.5122368127986152    TwSSM2Sh(2) - Mode 2, coefficient of x^2 term
-2.236214062644386      TwSSM2Sh(3) -       , coefficient of x^3 term
--4.450315822523695     TwSSM2Sh(4) -       , coefficient of x^4 term
-6.21339621261931       TwSSM2Sh(5) -       , coefficient of x^5 term
--2.4870576399413857    TwSSM2Sh(6) -       , coefficient of x^6 term
+1.0355964              TwSSM1Sh(2) - Mode 1, coefficient of x^2 term
+0.14425994             TwSSM1Sh(3) -       , coefficient of x^3 term
+-0.60684368            TwSSM1Sh(4) -       , coefficient of x^4 term
+0.60373509             TwSSM1Sh(5) -       , coefficient of x^5 term
+-0.17674775            TwSSM1Sh(6) -       , coefficient of x^6 term
+-2.45704796            TwSSM2Sh(2) - Mode 2, coefficient of x^2 term
+1.94256321             TwSSM2Sh(3) -       , coefficient of x^3 term
+3.87733083             TwSSM2Sh(4) -       , coefficient of x^4 term
+-2.47606538            TwSSM2Sh(5) -       , coefficient of x^5 term
+0.1132193              TwSSM2Sh(6) -       , coefficient of x^6 term

--- a/OpenFAST/IEA-15-240-RWT-UMaineSemi/IEA-15-240-RWT-UMaineSemi_ElastoDyn_tower.dat
+++ b/OpenFAST/IEA-15-240-RWT-UMaineSemi/IEA-15-240-RWT-UMaineSemi_ElastoDyn_tower.dat
@@ -28,24 +28,25 @@ IEA 15 MW offshore reference model on UMaine VolturnUS-S semi-submersible floati
  8.912274086706145e-01  2.596093483450980e+03  7.761060822822759e+11  7.761060822822759e+11
  1.000000000000000e+00  1.715031343116859e+03  3.489844253733395e+11  3.489844253733395e+11
 ---------------------- TOWER FORE-AFT MODE SHAPES ------------------------------
-0.9413693374950306     TwFAM1Sh(2) - Mode 1, coefficient of x^2 term
-0.3468546636521823     TwFAM1Sh(3) -       , coefficient of x^3 term
--1.0732425042270761    TwFAM1Sh(4) -       , coefficient of x^4 term
-1.3138921365298792     TwFAM1Sh(5) -       , coefficient of x^5 term
--0.5288736334500164    TwFAM1Sh(6) -       , coefficient of x^6 term
-139.39115610617628     TwFAM2Sh(2) - Mode 2, coefficient of x^2 term
-111.93048260721132     TwFAM2Sh(3) -       , coefficient of x^3 term
--656.9153343478758     TwFAM2Sh(4) -       , coefficient of x^4 term
-845.7553274809915      TwFAM2Sh(5) -       , coefficient of x^5 term
--439.16163184650327    TwFAM2Sh(6) -       , coefficient of x^6 term
+0.9408581              TwFAM1Sh(2) - Mode 1, coefficient of x^2 term
+0.34166013             TwFAM1Sh(3) -       , coefficient of x^3 term
+-1.0574787             TwFAM1Sh(4) -       , coefficient of x^4 term
+1.29320216             TwFAM1Sh(5) -       , coefficient of x^5 term
+-0.51824169            TwFAM1Sh(6) -       , coefficient of x^6 term
+-24.03994615           TwFAM2Sh(2) - Mode 2, coefficient of x^2 term
+-21.15631719           TwFAM2Sh(3) -       , coefficient of x^3 term
+121.23167423           TwFAM2Sh(4) -       , coefficient of x^4 term
+-156.46213366          TwFAM2Sh(5) -       , coefficient of x^5 term
+81.42672276            TwFAM2Sh(6) -       , coefficient of x^6 term
 ---------------------- TOWER SIDE-TO-SIDE MODE SHAPES --------------------------
-0.928651504815363      TwSSM1Sh(2) - Mode 1, coefficient of x^2 term
-0.3183110416167346     TwSSM1Sh(3) -       , coefficient of x^3 term
--0.9597593899992671    TwSSM1Sh(4) -       , coefficient of x^4 term
-1.164027965180537      TwSSM1Sh(5) -       , coefficient of x^5 term
--0.4512311216133674    TwSSM1Sh(6) -       , coefficient of x^6 term
--1970.3543341226898    TwSSM2Sh(2) - Mode 2, coefficient of x^2 term
--2284.293209902991     TwSSM2Sh(3) -       , coefficient of x^3 term
-11346.453188064506     TwSSM2Sh(4) -       , coefficient of x^4 term
--14750.85609454158     TwSSM2Sh(5) -       , coefficient of x^5 term
-7660.050450502754      TwSSM2Sh(6) -       , coefficient of x^6 term
+0.929743506            TwSSM1Sh(2) - Mode 1, coefficient of x^2 term
+0.316785925            TwSSM1Sh(3) -       , coefficient of x^3 term
+-0.958499163           TwSSM1Sh(4) -       , coefficient of x^4 term
+1.16248810             TwSSM1Sh(5) -       , coefficient of x^5 term
+-0.450518366           TwSSM1Sh(6) -       , coefficient of x^6 term
+-205.804355            TwSSM2Sh(2) - Mode 2, coefficient of x^2 term
+-238.132551            TwSSM2Sh(3) -       , coefficient of x^3 term
+1184.36489             TwSSM2Sh(4) -       , coefficient of x^4 term
+-1539.83060            TwSSM2Sh(5) -       , coefficient of x^5 term
+799.673147             TwSSM2Sh(6) -       , coefficient of x^6 term
+

--- a/OpenFAST/IEA-15-240-RWT-UMaineSemi/IEA-15-240-RWT-UMaineSemi_ElastoDyn_tower.dat
+++ b/OpenFAST/IEA-15-240-RWT-UMaineSemi/IEA-15-240-RWT-UMaineSemi_ElastoDyn_tower.dat
@@ -44,9 +44,9 @@ IEA 15 MW offshore reference model on UMaine VolturnUS-S semi-submersible floati
 -0.958499163           TwSSM1Sh(4) -       , coefficient of x^4 term
 1.16248810             TwSSM1Sh(5) -       , coefficient of x^5 term
 -0.450518366           TwSSM1Sh(6) -       , coefficient of x^6 term
--205.804355            TwSSM2Sh(2) - Mode 2, coefficient of x^2 term
--238.132551            TwSSM2Sh(3) -       , coefficient of x^3 term
-1184.36489             TwSSM2Sh(4) -       , coefficient of x^4 term
--1539.83060            TwSSM2Sh(5) -       , coefficient of x^5 term
-799.673147             TwSSM2Sh(6) -       , coefficient of x^6 term
+-760.74222548          TwSSM2Sh(2) - Mode 2, coefficient of x^2 term
+-880.24126995          TwSSM2Sh(3) -       , coefficient of x^3 term
+4377.92670711          TwSSM2Sh(4) -       , coefficient of x^4 term
+-5691.88226118         TwSSM2Sh(5) -       , coefficient of x^5 term
+2955.9390495           TwSSM2Sh(6) -       , coefficient of x^6 term
 

--- a/OpenFAST/IEA-15-240-RWT/IEA-15-240-RWT_ElastoDyn_blade.dat
+++ b/OpenFAST/IEA-15-240-RWT/IEA-15-240-RWT_ElastoDyn_blade.dat
@@ -65,18 +65,19 @@ IEA 15 MW Offshore Reference Turbine
  9.795918367346939e-01  3.600890296396286e-01 -1.508125114401624e+00  2.157201084316552e+01  1.296677095760643e+07  6.715371720843673e+07
  1.000000000000000e+00  3.681818181818181e-01 -1.242387706272970e+00  5.767382468564499e+00  1.862011072702549e+05  1.663313892259768e+06
 ---------------------- BLADE MODE SHAPES ---------------------------------------
--0.0752915102669993    BldFl1Sh(2) - Flap mode 1, coeff of x^2
-2.826459690437861      BldFl1Sh(3) -            , coeff of x^3
--3.2702836497367604    BldFl1Sh(4) -            , coeff of x^4
-2.252110669909933      BldFl1Sh(5) -            , coeff of x^5
--0.7329952003440339    BldFl1Sh(6) -            , coeff of x^6
--0.5285519130664843    BldFl2Sh(2) - Flap mode 2, coeff of x^2
-0.7090455925619575     BldFl2Sh(3) -            , coeff of x^3
--7.795036256009813     BldFl2Sh(4) -            , coeff of x^4
-15.797380956455061     BldFl2Sh(5) -            , coeff of x^5
--7.182838379940722     BldFl2Sh(6) -            , coeff of x^6
--0.02913195484596477   BldEdgSh(2) - Edge mode 1, coeff of x^2
-5.270503361982258      BldEdgSh(3) -            , coeff of x^3
--11.024746168421133    BldEdgSh(4) -            , coeff of x^4
-10.34151438983642      BldEdgSh(5) -            , coeff of x^5
--3.5581396285515794    BldEdgSh(6) -            , coeff of x^6
+0.369085029            BldFl1Sh(2) - Flap mode 1, coeff of x^2
+-1.17519817            BldFl1Sh(3) -            , coeff of x^3
+3.50694494             BldFl1Sh(4) -            , coeff of x^4
+-1.77020024            BldFl1Sh(5) -            , coeff of x^5
+0.0693684388           BldFl1Sh(6) -            , coeff of x^6
+-0.0152065892          BldFl2Sh(2) - Flap mode 2, coeff of x^2
+2.42097694             BldFl2Sh(3) -            , coeff of x^3
+-2.62066455            BldFl2Sh(4) -            , coeff of x^4
+1.87075906             BldFl2Sh(5) -            , coeff of x^5
+-0.655864859           BldFl2Sh(6) -            , coeff of x^6
+0.00200737012          BldEdgSh(2) - Edge mode 1, coeff of x^2
+4.76561913             BldEdgSh(3) -            , coeff of x^3
+-9.51015617            BldEdgSh(4) -            , coeff of x^4
+8.71930821             BldEdgSh(5) -            , coeff of x^5
+-2.97677854            BldEdgSh(6) -            , coeff of x^6
+

--- a/WISDEM/run_model.py
+++ b/WISDEM/run_model.py
@@ -124,7 +124,7 @@ def run_15mw(fname_wt_input):
     # Columns are ['Mass', 'CoM_x', 'CoM_y', 'CoM_z',
     #              'MoI_cm_xx', 'MoI_cm_yy', 'MoI_cm_zz', 'MoI_cm_xy', 'MoI_cm_xz', 'MoI_cm_yz',
     #              'MoI_TT_xx', 'MoI_TT_yy', 'MoI_TT_zz', 'MoI_TT_xy', 'MoI_TT_xz', 'MoI_TT_yz']
-    nacDF = prob.model.wt.drivese.nac._mass_table
+    nacDF = prob.model.wt.wt_rna.drivese.nac._mass_table
     hub_cm = prob["drivese.hub_system_cm"][0]
     L_drive = prob["drivese.L_drive"][0]
     tilt = prob.get_val('nacelle.uptilt', 'rad')[0]

--- a/WT_Ontology/IEA-15-240-RWT_VolturnUS-S.yaml
+++ b/WT_Ontology/IEA-15-240-RWT_VolturnUS-S.yaml
@@ -583,6 +583,8 @@ components:
             - name: main_column
               joint1: main_keel
               joint2: main_freeboard
+              Ca: [1.0, 1.0]
+              Cd: [0.8, 0.8]
               outer_shape:
                 shape: circular
                 outer_diameter:
@@ -610,6 +612,8 @@ components:
             - name: column1
               joint1: col1_keel
               joint2: col1_freeboard
+              Ca: [1.0, 1.0]
+              Cd: [0.8, 0.8]
               outer_shape: &col_out
                 shape: circular
                 outer_diameter:
@@ -647,6 +651,8 @@ components:
             - name: column2
               joint1: col2_keel
               joint2: col2_freeboard
+              Ca: [1.0, 1.0]
+              Cd: [0.8, 0.8]
               outer_shape: *col_out
               internal_structure: *col_int
               axial_joints:
@@ -662,6 +668,8 @@ components:
             - name: column3
               joint1: col3_keel
               joint2: col3_freeboard
+              Ca: [1.0, 1.0]
+              Cd: [0.8, 0.8]
               outer_shape: *col_out
               internal_structure: *col_int
               axial_joints:
@@ -678,6 +686,8 @@ components:
             - name: Y_pontoon_upper1
               joint1: main_upper_pontoon
               joint2: col1_upper_pontoon
+              Ca: [1.0, 1.0]
+              Cd: [0.8, 0.8]
               outer_shape: &pontup_out
                 shape: circular
                 outer_diameter:
@@ -694,18 +704,24 @@ components:
             - name: Y_pontoon_upper2
               joint1: main_upper_pontoon
               joint2: col2_upper_pontoon
+              Ca: [1.0, 1.0]
+              Cd: [0.8, 0.8]
               outer_shape: *pontup_out
               internal_structure: *pontup_int
 
             - name: Y_pontoon_upper3
               joint1: main_upper_pontoon
               joint2: col3_upper_pontoon
+              Ca: [1.0, 1.0]
+              Cd: [0.8, 0.8]
               outer_shape: *pontup_out
               internal_structure: *pontup_int
 
             - name: Y_pontoon_lower1
               joint1: main_lower_pontoon
               joint2: col1_lower_pontoon
+              Ca: [1.0, 1.0]
+              Cd: [0.8, 0.8]
               outer_shape: &pontlow_out
                 shape: circular
                 outer_diameter:
@@ -730,12 +746,16 @@ components:
             - name: Y_pontoon_lower2
               joint1: main_lower_pontoon
               joint2: col2_lower_pontoon
+              Ca: [1.0, 1.0]
+              Cd: [0.8, 0.8]
               outer_shape: *pontlow_out
               internal_structure: *pontlow_int
 
             - name: Y_pontoon_lower3
               joint1: main_lower_pontoon
               joint2: col3_lower_pontoon
+              Ca: [1.0, 1.0]
+              Cd: [0.8, 0.8]
               outer_shape: *pontlow_out
               internal_structure: *pontlow_int
     mooring:

--- a/WT_Ontology/IEA-15-240-RWT_VolturnUS-S.yaml
+++ b/WT_Ontology/IEA-15-240-RWT_VolturnUS-S.yaml
@@ -583,8 +583,6 @@ components:
             - name: main_column
               joint1: main_keel
               joint2: main_freeboard
-              Ca: 1.0
-              Cd: 0.8
               outer_shape:
                 shape: circular
                 outer_diameter:
@@ -612,8 +610,6 @@ components:
             - name: column1
               joint1: col1_keel
               joint2: col1_freeboard
-              Ca: 1.0
-              Cd: 0.8
               outer_shape: &col_out
                 shape: circular
                 outer_diameter:
@@ -651,8 +647,6 @@ components:
             - name: column2
               joint1: col2_keel
               joint2: col2_freeboard
-              Ca: 1.0
-              Cd: 0.8
               outer_shape: *col_out
               internal_structure: *col_int
               axial_joints:
@@ -668,8 +662,6 @@ components:
             - name: column3
               joint1: col3_keel
               joint2: col3_freeboard
-              Ca: 1.0
-              Cd: 0.8
               outer_shape: *col_out
               internal_structure: *col_int
               axial_joints:
@@ -686,8 +678,6 @@ components:
             - name: Y_pontoon_upper1
               joint1: main_upper_pontoon
               joint2: col1_upper_pontoon
-              Ca: 1.0
-              Cd: 0.8
               outer_shape: &pontup_out
                 shape: circular
                 outer_diameter:
@@ -704,24 +694,18 @@ components:
             - name: Y_pontoon_upper2
               joint1: main_upper_pontoon
               joint2: col2_upper_pontoon
-              Ca: 1.0
-              Cd: 0.8
               outer_shape: *pontup_out
               internal_structure: *pontup_int
 
             - name: Y_pontoon_upper3
               joint1: main_upper_pontoon
               joint2: col3_upper_pontoon
-              Ca: 1.0
-              Cd: 0.8
               outer_shape: *pontup_out
               internal_structure: *pontup_int
 
             - name: Y_pontoon_lower1
               joint1: main_lower_pontoon
               joint2: col1_lower_pontoon
-              Ca: 1.0
-              Cd: 0.8
               outer_shape: &pontlow_out
                 shape: circular
                 outer_diameter:
@@ -748,16 +732,12 @@ components:
               joint2: col2_lower_pontoon
               outer_shape: *pontlow_out
               internal_structure: *pontlow_int
-              Ca: 1.0
-              Cd: 0.8
 
             - name: Y_pontoon_lower3
               joint1: main_lower_pontoon
               joint2: col3_lower_pontoon
               outer_shape: *pontlow_out
               internal_structure: *pontlow_int
-              Ca: 1.0
-              Cd: 0.8
     mooring:
         nodes:
             - name: line1_anchor


### PR DESCRIPTION
## Purpose
Thanks to an Issue [posted](https://github.com/IEAWindTask37/IEA-22-280-RWT/issues/87) in the 22-MW repo, I started to dig deeper into the generation of the mode shape coefficients for OpenFAST by WISDEM and found a possibility for mistakes to arise.  After improving the WISDEM logic and approach, we found that the new mode shapes are nearly identical for the first mode, but are definitely improved for the second mode.

Note that this change only impacts OpenFAST ElastoDyn users (both blade and tower).

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation