### PR TITLE
VTK_fps is an integer

### DIFF
--- a/OpenFAST/IEA-15-240-RWT-Monopile/IEA-15-240-RWT-Monopile.fst
+++ b/OpenFAST/IEA-15-240-RWT-Monopile/IEA-15-240-RWT-Monopile.fst
@@ -68,4 +68,4 @@ False                  LinOutMod   - Write module-level linearization output fil
 0                      WrVTK       - VTK visualization data output: (switch) {0=none; 1=initialization data only; 2=animation}
 2                      VTK_type    - Type of VTK visualization data: (switch) {1=surfaces; 2=basic meshes (lines/points); 3=all meshes (debug)} [unused if WrVTK=0]
 False                  VTK_fields  - Write mesh fields to VTK data files? (flag) {true/false} [unused if WrVTK=0]
-15.0                   VTK_fps     - Frame rate for VTK output (frames per second){will use closest integer multiple of DT} [used only if WrVTK=2]
+15                     VTK_fps     - Frame rate for VTK output (frames per second){will use closest integer multiple of DT} [used only if WrVTK=2]

--- a/OpenFAST/IEA-15-240-RWT-Monopile_wDTUcontroller/IEA-15-240-RWT-Monopile_wDTUcontroller.fst
+++ b/OpenFAST/IEA-15-240-RWT-Monopile_wDTUcontroller/IEA-15-240-RWT-Monopile_wDTUcontroller.fst
@@ -57,4 +57,4 @@ False                  LinOutMod   - Write module-level linearization output fil
 0                      WrVTK       - VTK visualization data output: (switch) {0=none; 1=initialization data only; 2=animation}
 2                      VTK_type    - Type of VTK visualization data: (switch) {1=surfaces; 2=basic meshes (lines/points); 3=all meshes (debug)} [unused if WrVTK=0]
 False                  VTK_fields  - Write mesh fields to VTK data files? (flag) {true/false} [unused if WrVTK=0]
-15.0                   VTK_fps     - Frame rate for VTK output (frames per second){will use closest integer multiple of DT} [used only if WrVTK=2]
+15                     VTK_fps     - Frame rate for VTK output (frames per second){will use closest integer multiple of DT} [used only if WrVTK=2]

--- a/OpenFAST/IEA-15-240-RWT-OLAF/IEA-15-240-RWT_OLAF.fst
+++ b/OpenFAST/IEA-15-240-RWT-OLAF/IEA-15-240-RWT_OLAF.fst
@@ -68,4 +68,4 @@ False                  LinOutMod   - Write module-level linearization output fil
 0                      WrVTK       - VTK visualization data output: (switch) {0=none; 1=initialization data only; 2=animation}
 2                      VTK_type    - Type of VTK visualization data: (switch) {1=surfaces; 2=basic meshes (lines/points); 3=all meshes (debug)} [unused if WrVTK=0]
 False                  VTK_fields  - Write mesh fields to VTK data files? (flag) {true/false} [unused if WrVTK=0]
-15.0                   VTK_fps     - Frame rate for VTK output (frames per second){will use closest integer multiple of DT} [used only if WrVTK=2]
+15                     VTK_fps     - Frame rate for VTK output (frames per second){will use closest integer multiple of DT} [used only if WrVTK=2]

--- a/OpenFAST/IEA-15-240-RWT-UMaineSemi/IEA-15-240-RWT-UMaineSemi.fst
+++ b/OpenFAST/IEA-15-240-RWT-UMaineSemi/IEA-15-240-RWT-UMaineSemi.fst
@@ -68,4 +68,4 @@ False                  LinOutMod   - Write module-level linearization output fil
 0                      WrVTK       - VTK visualization data output: (switch) {0=none; 1=initialization data only; 2=animation}
 2                      VTK_type    - Type of VTK visualization data: (switch) {1=surfaces; 2=basic meshes (lines/points); 3=all meshes (debug)} [unused if WrVTK=0]
 False                  VTK_fields  - Write mesh fields to VTK data files? (flag) {true/false} [unused if WrVTK=0]
-15.0                   VTK_fps     - Frame rate for VTK output (frames per second){will use closest integer multiple of DT} [used only if WrVTK=2]
+15                     VTK_fps     - Frame rate for VTK output (frames per second){will use closest integer multiple of DT} [used only if WrVTK=2]


### PR DESCRIPTION
## Purpose
VTK_fps should be an integer. OpenFAST does not error out, but the ACDC app does. Derek has now built in some robustness, but still, this input should be an integer

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation