### PR TITLE
Fix #271: Re-tuned controller for the monopile version

### DIFF
--- a/HAWC2/IEA-15-240-RWT-Monopile/htc/IEA_15MW_RWT_Monopile.htc
+++ b/HAWC2/IEA-15-240-RWT-Monopile/htc/IEA_15MW_RWT_Monopile.htc
@@ -209,32 +209,32 @@ begin dll;
     begin init ;
        ; Overall parameters
       constant   1  15000.0        ; Rated power [kW]
-      constant   2  0.524          ; Minimum rotor (LSS) speed [rad/s]
-      constant   3  0.792          ; Rated rotor (LSS) speed [rad/s]
+      constant   2  0.52360       ; Minimum rotor (LSS) speed [rad/s]
+      constant   3  0.79168        ; Rated rotor (LSS) speed [rad/s]
       constant   4  21586451.33303 ; Maximum allowable generator torque [Nm]
       constant   5  100.0          ; Minimum pitch angle, theta_min [deg],
                                    ; if |theta_min|>90, then a table of <wsp,theta_min> is read ;
                                    ; from a file named 'wptable.n', where n=int(theta_min)
       constant   6  90.0           ; Maximum pitch angle [deg]
       constant   7  2.0            ; Maximum pitch velocity operation [deg/s]
-      constant   8  0.15915       ; Frequency of generator speed filter [Hz]
+      constant   8  0.315        ; Frequency of generator speed filter [Hz], tuned to 2.5P like for the IEA 22 MW.
       constant   9  0.7           ; Damping ratio of speed filter [-]
       constant  10  1.01          ; Frequency of free-free DT torsion mode [Hz], if zero no notch filter used
       ; Partial load control parameters
-      constant  11  0.302217E+08 ; Optimal Cp tracking K factor [Nm/(rad/s)^2], ;
+      constant  11  0.302485E+08 ; Optimal Cp tracking K factor [Nm/(rad/s)^2], ;
                                   ; Qg=K*Omega^2, K=eta*0.5*rho*A*Cp_opt*R^3/lambda_opt^3
-      constant  12  0.112427E+09 ; Proportional gain of torque controller [Nm/(rad/s)]
-      constant  13  0.201829E+08 ; Integral gain of torque controller [Nm/rad]
+      constant  12  0.150858E+09 ; Proportional gain of torque controller [Nm/(rad/s)]
+      constant  13  0.338526E+08 ; Integral gain of torque controller [Nm/rad]
       constant  14  0.0           ; Differential gain of torque controller [Nm/(rad/s^2)]
 ;     Full load control parameters
       constant  15  0             ; Generator control switch [1=constant power, 0=constant torque]
-      constant  16  0.640241E+00 ; Proportional gain of pitch controller [rad/(rad/s)]
-      constant  17  0.862019E-01 ; Integral gain of pitch controller [rad/rad]
+      constant  16  0.646235E+00 ; Proportional gain of pitch controller [rad/(rad/s)]
+      constant  17  0.870088E-01 ; Integral gain of pitch controller [rad/rad]
       constant  18  0.0           ; Differential gain of pitch controller [rad/(rad/s^2)]
       constant  19  0.4e-8        ; Proportional power error gain [rad/W]
       constant  20  0.4e-8        ; Integral power error gain [rad/(Ws)]
-      constant  21  11.95434      ; Coefficient of linear term in aerodynamic gain scheduling, KK1 [deg]
-      constant  22  720.25183     ; Coefficient of quadratic term in aerodynamic gain scheduling, KK2 [deg^2] &
+      constant  21  12.09150      ; Coefficient of linear term in aerodynamic gain scheduling, KK1 [deg]
+      constant  22  705.91663     ; Coefficient of quadratic term in aerodynamic gain scheduling, KK2 [deg^2] &
                                     ; (if zero, KK1 = pitch angle at double gain)
       constant  23  1.5            ; Relative speed for double nonlinear gain [-]
 ;     Cut-in simulation parameters


### PR DESCRIPTION
In #271 Fabio noticed some large vibrations with steady wind above rated. Fabio suggested that increasing the generator speed filter frequency ameliorates this issue. This PR does the following changes to the monopile model:

- Set the frequency of the generator speed filter to 2.5P, as done for the IEA 22 MW. This means 0.315 Hz, which is about double of the previous value.
- Copied all control parameters from HAWCStab2 2.16. In particular, the gains below rated are now higher.
- Added a few more decimals to the minimum and rated rotor speeds.

The improved performance is confirmed by the following parameter study, where I have varied the generator speed filter frequency and computed the std of the pitch angle. As we can see, the old tuning of 0.16 is nearly the worst possible choice.

<img width="1920" height="967" alt="pitch_std" src="https://github.com/user-attachments/assets/bff9352c-ac44-41f7-ada8-4e179072e2f0" />

<img width="1920" height="967" alt="pitch_std_zoom" src="https://github.com/user-attachments/assets/5961cb21-04f6-42ab-b15e-0ed63219b166" />
